### PR TITLE
Fixing typo in readme and adding example for 'Require user'

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,15 @@ APXS_PATH variable to your apxs or apxs2 as appropriate)
 
 Configure the module:
 
-    LoadModule authn_persona_module modules/authn_persona_module.so
+    LoadModule authn_persona_module modules/mod_authn_persona.so
 
     <Location />
        AuthType Persona
        Require valid-user # XXX: figure out how this should work
        # Or, require users with host/IdP example.com:
        # Require persona-idp example.com
+       # Or, require specific users
+       # Require user user@example.com
     </Location>
 
 This will cause the module to require Persona authentication for all


### PR DESCRIPTION
The filename of the shared object that's built is "mod_authn_persona.so" not "authn_persona_module.so". I've also added a couple lines illustrating the third usage example of 'Require user'
