### PR TITLE
Reduce log level in Auth_persona_check_cookie

### DIFF
--- a/src/mod_authnz_persona.c
+++ b/src/mod_authnz_persona.c
@@ -121,7 +121,7 @@ static int Auth_persona_check_cookie(request_rec *r)
   if (!persona_authn_active(r)) {
     return DECLINED;
   }
-  ap_log_rerror(APLOG_MARK, APLOG_ERR|APLOG_NOERRNO, 0, r, ERRTAG "Auth_persona_check_cookie");
+  ap_log_rerror(APLOG_MARK, APLOG_DEBUG|APLOG_NOERRNO, 0, r, ERRTAG "Auth_persona_check_cookie");
 
   // We'll trade you a valid assertion for a session cookie!
   // this is a programmatic XHR request.


### PR DESCRIPTION
Currently every request generates a log message at ERROR, which is very noisy during normal usage. This simply changes it down to APLOG_DEBUG.